### PR TITLE
Update Chisel from 5.1.0 to 6.5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ env:
   VERILATOR_REPO: https://github.com/verilator/verilator
   VERILATOR_DIR: verilator
   VERILATOR_VERSION_TAG: v4.228
-  FIRTOOL_VERSION: v1.43.0
-  FIRTOOL_VERSION_TAG: firtool-1.43.0
+  FIRTOOL_VERSION: v1.62.0
+  FIRTOOL_VERSION_TAG: firtool-1.62.0
 
 jobs:
   test:
@@ -39,7 +39,7 @@ jobs:
         cache: 'sbt'
     - name: Install firtool ${{ env.FIRTOOL_VERSION }}
       run: |
-        wget -q -O - "https://github.com/llvm/circt/releases/download/${{ env.FIRTOOL_VERSION_TAG }}/firrtl-bin-ubuntu-20.04.tar.gz" | tar -zx
+        wget -q -O - "https://github.com/llvm/circt/releases/download/${{ env.FIRTOOL_VERSION_TAG }}/firrtl-bin-linux-x64.tar.gz" | tar -zx
         sudo mv "${{ env.FIRTOOL_VERSION_TAG }}/bin/firtool" /usr/local/bin
     - name: "Cache: Verilator ${{ env.VERILATOR_VERSION_TAG }}"
       uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ work just as it did before. To that end, the following classes/traits have been 
 * BinaryPoint, KnownBinaryPoint, UnknownBinaryPoint
 * HasBinaryPoint
 
-Currently, this library works with [Chisel v5.1.0](https://github.com/chipsalliance/chisel/releases/v5.1.0).
+Currently, this library works with [Chisel v6.5.0](https://github.com/chipsalliance/chisel/releases/v6.5.0).
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.14"
 scalacOptions += "-language:higherKinds"
-addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full)
+addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.3" cross CrossVersion.full)
 
 scalacOptions += "-Ydelambdafy:inline"
 scalacOptions ++= Seq(
@@ -12,7 +12,7 @@ scalacOptions ++= Seq(
   "-language:reflectiveCalls",
   "-Ymacro-annotations"
 )
-val chiselVersion = "5.1.0"
+val chiselVersion = "6.5.0"
 addCompilerPlugin("org.chipsalliance" %% "chisel-plugin" % chiselVersion cross CrossVersion.full)
 libraryDependencies ++= Seq(
   "org.chipsalliance" %% "chisel" % chiselVersion,

--- a/src/main/scala/fixedpoint/FixedPoint.scala
+++ b/src/main/scala/fixedpoint/FixedPoint.scala
@@ -16,7 +16,6 @@ package fixedpoint
 import chisel3._
 import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 import chisel3.experimental.OpaqueType
-import chisel3.internal.firrtl.{KnownWidth, UnknownWidth, Width}
 import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.{SourceInfoTransform, SourceInfoWhiteboxTransform}
 

--- a/src/test/scala/FixedPointSpec.scala
+++ b/src/test/scala/FixedPointSpec.scala
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import chisel3.internal.firrtl.UnknownWidth
 import circt.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.{Mux => _, _}
@@ -167,7 +166,7 @@ class FixedPointUnaryFuncTester(f: FixedPoint => FixedPoint, inExpected: Seq[(Fi
   inExpected.foreach {
     case (in, expected) =>
       val out = f(in)
-      assert(out === expected, f"Wrong value: in=${in}; out=${out}; expected=${expected}")
+      assert(out === expected, cf"Wrong value: in=${in}; out=${out}; expected=${expected}")
       assert(out.widthOption == in.widthOption, f"Width changed: in=${in}; out=${out}")
       assert(out.binaryPoint == in.binaryPoint, f"Binary point changed: in=${in}; out=${out}")
   }


### PR DESCRIPTION
This just involves bumping some tool versions and resolving deprecated-package warnings.

After trying to compile this with the newly-released Chisel 7.0.0-M2, I noticed some issues that weren't so simple to resolve, so I figured we should do a more incremental update to 6.x first.