### PR TITLE
Update Chisel from 6.5.0 to 7.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ env:
   JDK_DIST: temurin
   VERILATOR_REPO: https://github.com/verilator/verilator
   VERILATOR_DIR: verilator
-  VERILATOR_VERSION_TAG: v4.228
+  VERILATOR_VERSION_TAG: v5.034
   FIRTOOL_VERSION_TAG: firtool-1.111.1
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ env:
   VERILATOR_REPO: https://github.com/verilator/verilator
   VERILATOR_DIR: verilator
   VERILATOR_VERSION_TAG: v5.034
-  FIRTOOL_VERSION_TAG: firtool-1.111.1
+  FIRTOOL_VERSION_TAG: firtool-1.113.0
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  JDK_VERSION: 20
+  JDK_VERSION: 21
   JDK_DIST: temurin
   VERILATOR_REPO: https://github.com/verilator/verilator
   VERILATOR_DIR: verilator
@@ -29,24 +29,39 @@ jobs:
 
     steps:
     - name: Check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up JDK ${{ env.JDK_VERSION }} (${{ env.JDK_DIST }})
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ env.JDK_VERSION }}
         distribution: ${{ env.JDK_DIST }}
         cache: 'sbt'
+    - name: Install sbt
+      uses: sbt/setup-sbt@v1
     - name: Install firtool ${{ env.FIRTOOL_VERSION_TAG }}
+      id: install-circt
+      uses: circt/install-circt@v1.1.1
+      with:
+        version: ${{ env.FIRTOOL_VERSION_TAG }}
+    - name: Set CHISEL_FIRTOOL_PATH
+      if: steps.install-circt.outcome == 'success'
       run: |
-        wget -q -O - "https://github.com/llvm/circt/releases/download/${{ env.FIRTOOL_VERSION_TAG }}/firrtl-bin-linux-x64.tar.gz" | tar -zx
-        sudo mv "${{ env.FIRTOOL_VERSION_TAG }}/bin/firtool" /usr/local/bin
+        dir=$(dirname $(which firtool))
+        echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
+    - name: Print firtool version
+      if: steps.install-circt.outcome == 'success'
+      run: |
+        echo "The CIRCT version used is:" >> $GITHUB_STEP_SUMMARY
+        echo \`\`\` >> $GITHUB_STEP_SUMMARY
+        $CHISEL_FIRTOOL_PATH/firtool -version >> $GITHUB_STEP_SUMMARY
+        echo \`\`\` >> $GITHUB_STEP_SUMMARY
     - name: "Cache: Verilator ${{ env.VERILATOR_VERSION_TAG }}"
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: install-cache
       with:
         path: ${{ env.VERILATOR_DIR }}
         key: ${{ runner.os }}-${{ runner.arch }}-verilator-${{ env.VERILATOR_VERSION_TAG }}
-    
+
     - name: Install Verilator ${{ env.VERILATOR_VERSION_TAG }} from cache
       if: steps.install-cache.outputs.cache-hit == 'true'
       run: |
@@ -57,7 +72,7 @@ jobs:
         sudo apt-get install -my libfl2 || true  # Ubuntu only (ignore if gives error)
         sudo apt-get install -my libfl-dev || true  # Ubuntu only (ignore if gives error)
         sudo apt-get install -my zlibc zlib1g zlib1g-dev || true  # Ubuntu only (ignore if gives error)
-        
+
         cd "$VERILATOR_DIR"
         sudo make install
         verilator --version
@@ -71,7 +86,7 @@ jobs:
         sudo apt-get install -my libfl2 || true  # Ubuntu only (ignore if gives error)
         sudo apt-get install -my libfl-dev || true  # Ubuntu only (ignore if gives error)
         sudo apt-get install -my zlibc zlib1g zlib1g-dev || true  # Ubuntu only (ignore if gives error)
-        
+
         git clone "$VERILATOR_REPO" "$VERILATOR_DIR"
         cd "$VERILATOR_DIR"
         git checkout "$VERILATOR_VERSION_TAG"
@@ -80,7 +95,7 @@ jobs:
         make -j "$(nproc)"
         sudo make install
         verilator --version
-    
+
     - name: Check scalafmt
       run: sbt scalafmtCheckAll
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,7 @@ env:
   VERILATOR_REPO: https://github.com/verilator/verilator
   VERILATOR_DIR: verilator
   VERILATOR_VERSION_TAG: v4.228
-  FIRTOOL_VERSION: v1.62.0
-  FIRTOOL_VERSION_TAG: firtool-1.62.0
+  FIRTOOL_VERSION_TAG: firtool-1.111.1
 
 jobs:
   test:
@@ -37,7 +36,7 @@ jobs:
         java-version: ${{ env.JDK_VERSION }}
         distribution: ${{ env.JDK_DIST }}
         cache: 'sbt'
-    - name: Install firtool ${{ env.FIRTOOL_VERSION }}
+    - name: Install firtool ${{ env.FIRTOOL_VERSION_TAG }}
       run: |
         wget -q -O - "https://github.com/llvm/circt/releases/download/${{ env.FIRTOOL_VERSION_TAG }}/firrtl-bin-linux-x64.tar.gz" | tar -zx
         sudo mv "${{ env.FIRTOOL_VERSION_TAG }}/bin/firtool" /usr/local/bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ env:
   JDK_DIST: temurin
   VERILATOR_REPO: https://github.com/verilator/verilator
   VERILATOR_DIR: verilator
-  VERILATOR_VERSION_TAG: v5.034
-  FIRTOOL_VERSION_TAG: firtool-1.113.0
+  VERILATOR_VERSION_TAG: v5.036
+  FIRTOOL_VERSION_TAG: firtool-1.117.0
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ env:
   JDK_DIST: temurin
   VERILATOR_REPO: https://github.com/verilator/verilator
   VERILATOR_DIR: verilator
-  VERILATOR_VERSION_TAG: v5.036
-  FIRTOOL_VERSION_TAG: firtool-1.117.0
+  VERILATOR_VERSION_TAG: v5.042
+  FIRTOOL_VERSION_TAG: firtool-1.138.0
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
- out/
+build/
+out/
 generated/
 /lib/firrtl.jar
 .classpath

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,26 +1,20 @@
-version = 2.6.4
+version = 3.9.3
+runner.dialect = scala213
 
 maxColumn = 120
-align = most
 continuationIndent.defnSite = 2
 assumeStandardLibraryStripMargin = true
-docstrings = ScalaDoc
+docstrings.style = SpaceAsterisk
+docstrings.wrap = "no"
 lineEndings = preserve
-includeCurlyBraceInSelectChains = false
-danglingParentheses = true
+newlines.selectChains.classicCanStartWithBraceApply = false
 
-align.tokens.add = [
-  {
-    code = ":"
-  }
+align.preset = more
+align.tokens."+" = [
+  { code = ":", owner = "Term.ApplyInfix" },
 ]
 
-newlines.alwaysBeforeCurlyBraceLambdaParams = false
-newlines.alwaysBeforeMultilineDef = false
-newlines.implicitParamListModifierForce = [before]
-
-verticalMultiline.atDefnSite = true
-
-optIn.annotationNewlines = true
+newlines.beforeCurlyLambdaParams = multiline
+newlines.implicitParamListModifierPrefer = before
 
 rewrite.rules = [SortImports, PreferCurlyFors, AvoidInfix]

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,8 @@ addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.3" cross CrossVers
 scalacOptions += "-Ydelambdafy:inline"
 scalacOptions ++= Seq(
   "-deprecation",
-  "-encoding", "UTF-8",
+  "-encoding",
+  "UTF-8",
   "-feature",
   "-unchecked",
   "-Xfatal-warnings",
@@ -15,9 +16,9 @@ scalacOptions ++= Seq(
 val chiselVersion = "7.0.0-M2+639-5df5515f-SNAPSHOT"
 addCompilerPlugin("org.chipsalliance" %% "chisel-plugin" % chiselVersion cross CrossVersion.full)
 libraryDependencies ++= Seq(
-  "org.chipsalliance" %% "chisel" % chiselVersion,
-  "org.scalatest" %% "scalatest" % "3.2.15" % "test",
-  "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test",
+  "org.chipsalliance" %% "chisel"          % chiselVersion,
+  "org.scalatest"     %% "scalatest"       % "3.2.15"  % "test",
+  "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test"
 )
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@ val chiselVersion = "7.0.0-M2+639-5df5515f-SNAPSHOT"
 addCompilerPlugin("org.chipsalliance" %% "chisel-plugin" % chiselVersion cross CrossVersion.full)
 libraryDependencies ++= Seq(
   "org.chipsalliance" %% "chisel"          % chiselVersion,
-  "org.scalatest"     %% "scalatest"       % "3.2.15"  % "test",
-  "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test"
+  "org.scalatest"     %% "scalatest"       % "3.2.19"   % "test",
+  "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test"
 )
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-scalaVersion := "2.13.16"
+scalaVersion := "2.13.18"
 scalacOptions += "-language:higherKinds"
-addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.3" cross CrossVersion.full)
+addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.4" cross CrossVersion.full)
 
 scalacOptions += "-Ydelambdafy:inline"
 scalacOptions ++= Seq(
@@ -13,7 +13,7 @@ scalacOptions ++= Seq(
   "-language:reflectiveCalls",
   "-Ymacro-annotations"
 )
-val chiselVersion = "7.0.0-RC1"
+val chiselVersion = "7.5.0"
 addCompilerPlugin("org.chipsalliance" %% "chisel-plugin" % chiselVersion cross CrossVersion.full)
 libraryDependencies ++= Seq(
   "org.chipsalliance" %% "chisel"          % chiselVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions ++= Seq(
   "-language:reflectiveCalls",
   "-Ymacro-annotations"
 )
-val chiselVersion = "7.0.0-M2+639-5df5515f-SNAPSHOT"
+val chiselVersion = "7.0.0-M2+678-dca5fc11-SNAPSHOT"
 addCompilerPlugin("org.chipsalliance" %% "chisel-plugin" % chiselVersion cross CrossVersion.full)
 libraryDependencies ++= Seq(
   "org.chipsalliance" %% "chisel"          % chiselVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -13,13 +13,12 @@ scalacOptions ++= Seq(
   "-language:reflectiveCalls",
   "-Ymacro-annotations"
 )
-val chiselVersion = "7.0.0-M2+678-dca5fc11-SNAPSHOT"
+val chiselVersion = "7.0.0-RC1"
 addCompilerPlugin("org.chipsalliance" %% "chisel-plugin" % chiselVersion cross CrossVersion.full)
 libraryDependencies ++= Seq(
   "org.chipsalliance" %% "chisel"          % chiselVersion,
   "org.scalatest"     %% "scalatest"       % "3.2.19"   % "test",
   "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test"
 )
-resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 Test / parallelExecution := false

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.14"
+scalaVersion := "2.13.16"
 scalacOptions += "-language:higherKinds"
 addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.3" cross CrossVersion.full)
 
@@ -12,12 +12,13 @@ scalacOptions ++= Seq(
   "-language:reflectiveCalls",
   "-Ymacro-annotations"
 )
-val chiselVersion = "6.5.0"
+val chiselVersion = "7.0.0-M2+639-5df5515f-SNAPSHOT"
 addCompilerPlugin("org.chipsalliance" %% "chisel-plugin" % chiselVersion cross CrossVersion.full)
 libraryDependencies ++= Seq(
   "org.chipsalliance" %% "chisel" % chiselVersion,
   "org.scalatest" %% "scalatest" % "3.2.15" % "test",
   "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test",
 )
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 Test / parallelExecution := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.10.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-val scalafmtPluginVersion = "2.4.6"
+val scalafmtPluginVersion = "2.5.4"
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % scalafmtPluginVersion)

--- a/src/main/scala/fixedpoint/BinaryPoint.scala
+++ b/src/main/scala/fixedpoint/BinaryPoint.scala
@@ -76,33 +76,33 @@ trait HasBinaryPoint {
 
 object BinaryPoint {
   def apply(x: Int): BinaryPoint = KnownBinaryPoint(x)
-  def apply(): BinaryPoint = UnknownBinaryPoint
+  def apply(): BinaryPoint       = UnknownBinaryPoint
 }
 
 sealed abstract class BinaryPoint {
   type W = Int
-  def max(that:              BinaryPoint): BinaryPoint = this.op(that, _ max _)
-  def +(that:                BinaryPoint): BinaryPoint = this.op(that, _ + _)
-  def +(that:                Int):         BinaryPoint = this.op(this, (a, b) => a + that)
-  def shiftRight(that:       Int): BinaryPoint = this.op(this, (a, b) => 0.max(a - that))
+  def max(that: BinaryPoint): BinaryPoint = this.op(that, _ max _)
+  def +(that: BinaryPoint): BinaryPoint   = this.op(that, _ + _)
+  def +(that: Int): BinaryPoint           = this.op(this, (a, b) => a + that)
+  def shiftRight(that: Int): BinaryPoint  = this.op(this, (a, b) => 0.max(a - that))
   def dynamicShiftLeft(that: BinaryPoint): BinaryPoint =
     this.op(that, (a, b) => a + (1 << b) - 1)
 
   def known: Boolean
-  def get:   W
+  def get: W
   protected def op(that: BinaryPoint, f: (W, W) => W): BinaryPoint
 }
 
 case object UnknownBinaryPoint extends BinaryPoint {
-  def known: Boolean = false
-  def get:   Int = None.get
+  def known: Boolean                                     = false
+  def get: Int                                           = None.get
   def op(that: BinaryPoint, f: (W, W) => W): BinaryPoint = this
-  override def toString: String = ""
+  override def toString: String                          = ""
 }
 
 sealed case class KnownBinaryPoint(value: Int) extends BinaryPoint {
   def known: Boolean = true
-  def get:   Int = value
+  def get: Int       = value
   def op(that: BinaryPoint, f: (W, W) => W): BinaryPoint = that match {
     case KnownBinaryPoint(x) => KnownBinaryPoint(f(value, x))
     case _                   => that

--- a/src/main/scala/fixedpoint/FixedPoint.scala
+++ b/src/main/scala/fixedpoint/FixedPoint.scala
@@ -88,7 +88,7 @@ object FixedPoint extends NumObject {
     */
   private[fixedpoint] def fromData(
     binaryPoint: BinaryPoint,
-    data:        Data,
+    data: Data,
     widthOption: Option[Width] = None
   )(
     implicit sourceInfo: SourceInfo
@@ -122,7 +122,7 @@ object FixedPoint extends NumObject {
         val maxBP = bps.fold(0.BP)(_.max(_))
         val maxWidth = in.map {
           case el: FixedPoint => recreateWidth(el) + (maxBP.get - el.binaryPoint.get)
-          case nonFp => recreateWidth(nonFp)
+          case nonFp          => recreateWidth(nonFp)
         }.fold(0.W)(_.max(_))
 
         in.map {
@@ -175,8 +175,8 @@ sealed class FixedPoint private[fixedpoint] (width: Width, private var _inferred
     with Num[FixedPoint]
     with HasBinaryPoint {
   if (binaryPoint.known) require(binaryPoint.get >= 0, "Negative binary point is not supported")
-  private val data: SInt = SInt(width)
-  val elements:     SeqMap[String, SInt] = SeqMap("" -> data)
+  private val data: SInt             = SInt(width)
+  val elements: SeqMap[String, SInt] = SeqMap("" -> data)
 
   def binaryPoint: BinaryPoint = _inferredBinaryPoint
 

--- a/src/main/scala/fixedpoint/FixedPoint.scala
+++ b/src/main/scala/fixedpoint/FixedPoint.scala
@@ -21,12 +21,13 @@ import chisel3.internal.sourceinfo.{SourceInfoTransform, SourceInfoWhiteboxTrans
 
 import scala.collection.immutable.SeqMap
 import scala.language.experimental.macros
+import scala.math.BigDecimal.RoundingMode.RoundingMode
 import chisel3.util.Cat
 
 object FixedPoint extends NumObject {
 
   /** Create a FixedPoint type with inferred width. */
-  def apply(): FixedPoint = apply(UnknownWidth(), BinaryPoint())
+  def apply(): FixedPoint = apply(UnknownWidth, BinaryPoint())
 
   /** Create a FixedPoint type or port with fixed width. */
   def apply(width: Width, binaryPoint: BinaryPoint): FixedPoint = new FixedPoint(width, binaryPoint)
@@ -42,7 +43,7 @@ object FixedPoint extends NumObject {
     * Use PrivateObject to force users to specify width and binaryPoint by name
     */
   def fromBigInt(value: BigInt, binaryPoint: BinaryPoint = 0.BP): FixedPoint = {
-    apply(value, UnknownWidth(), binaryPoint)
+    apply(value, UnknownWidth, binaryPoint)
   }
 
   /** Create a FixedPoint literal with inferred width from BigInt.
@@ -50,7 +51,7 @@ object FixedPoint extends NumObject {
     */
   def fromBigInt(value: BigInt, width: Int, binaryPoint: Int): FixedPoint =
     if (width == -1) {
-      apply(value, UnknownWidth(), BinaryPoint(binaryPoint))
+      apply(value, UnknownWidth, BinaryPoint(binaryPoint))
     } else {
       apply(value, KnownWidth(width), BinaryPoint(binaryPoint))
     }
@@ -103,7 +104,7 @@ object FixedPoint extends NumObject {
   }
 
   private[fixedpoint] def recreateWidth[T <: Data](d: T): Width = {
-    d.widthOption.fold[Width](UnknownWidth())(_.W)
+    d.widthOption.fold[Width](UnknownWidth)(_.W)
   }
 
   /** Align all FixedPoints in a (possibly heterogeneous) sequence by width and binary point
@@ -145,7 +146,7 @@ object FixedPoint extends NumObject {
 
     implicit class fromDoubleToLiteral(double: Double) {
       def F(binaryPoint: BinaryPoint): FixedPoint = {
-        FixedPoint.fromDouble(double, UnknownWidth(), binaryPoint)
+        FixedPoint.fromDouble(double, UnknownWidth, binaryPoint)
       }
 
       def F(width: Width, binaryPoint: BinaryPoint): FixedPoint = {
@@ -155,7 +156,7 @@ object FixedPoint extends NumObject {
 
     implicit class fromBigDecimalToLiteral(bigDecimal: BigDecimal) {
       def F(binaryPoint: BinaryPoint): FixedPoint = {
-        FixedPoint.fromBigDecimal(bigDecimal, UnknownWidth(), binaryPoint)
+        FixedPoint.fromBigDecimal(bigDecimal, UnknownWidth, binaryPoint)
       }
 
       def F(width: Width, binaryPoint: BinaryPoint): FixedPoint = {
@@ -222,8 +223,6 @@ sealed class FixedPoint private[fixedpoint] (width: Width, private var _inferred
   def do_-&(that: FixedPoint)(implicit sourceInfo: SourceInfo): FixedPoint = additiveOp(that, _ -& _)
 
   def do_unary_-(implicit sourceInfo: SourceInfo): FixedPoint = FixedPoint.fromData(binaryPoint, -data)
-
-  def do_unary_-%(implicit sourceInfo: SourceInfo): FixedPoint = FixedPoint.fromData(binaryPoint, data.unary_-%)
 
   override def do_*(that: FixedPoint)(implicit sourceInfo: SourceInfo): FixedPoint =
     FixedPoint.fromData(binaryPoint + that.binaryPoint, data * that.data)
@@ -325,8 +324,10 @@ sealed class FixedPoint private[fixedpoint] (width: Width, private var _inferred
 
   override def bulkConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = connectOp(that, _ <> _)
 
-  override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo): Unit = {
-    this.data := that.asTypeOf(this.data)
+  override protected def _fromUInt(that: UInt)(implicit sourceInfo: SourceInfo): Data = {
+    val _w = Wire(this.cloneType)
+    _w.data := that.asTypeOf(this.data)
+    _w
   }
 
   def apply(x: BigInt): Bool = data.apply(x)

--- a/src/main/scala/fixedpoint/shadow/MuxDefs.scala
+++ b/src/main/scala/fixedpoint/shadow/MuxDefs.scala
@@ -16,9 +16,9 @@ object Mux extends SourceInfoDoc {
 
 object Mux1H {
   def apply[T <: Data](sel: Seq[Bool], in: Seq[T]): T = chisel3.util.Mux1H(sel, Util.processArgs(in))
-  def apply[T <: Data](in:  Iterable[(Bool, T)]): T = chisel3.util.Mux1H(Util.processArgs(in))
-  def apply[T <: Data](sel: UInt, in: Seq[T]): T = chisel3.util.Mux1H(sel, Util.processArgs(in))
-  def apply(sel:            UInt, in: UInt):   Bool = chisel3.util.Mux1H(sel, in)
+  def apply[T <: Data](in: Iterable[(Bool, T)]): T    = chisel3.util.Mux1H(Util.processArgs(in))
+  def apply[T <: Data](sel: UInt, in: Seq[T]): T      = chisel3.util.Mux1H(sel, Util.processArgs(in))
+  def apply(sel: UInt, in: UInt): Bool                = chisel3.util.Mux1H(sel, in)
 }
 
 ///** Builds a Mux tree under the assumption that multiple select signals
@@ -35,9 +35,9 @@ object Mux1H {
 // * Returns the output of the Mux tree.
 // */
 object PriorityMux {
-  def apply[T <: Data](in:  Seq[(Bool, T)]): T = chisel3.util.PriorityMux(Util.processArgs[Bool, T](in))
+  def apply[T <: Data](in: Seq[(Bool, T)]): T         = chisel3.util.PriorityMux(Util.processArgs[Bool, T](in))
   def apply[T <: Data](sel: Seq[Bool], in: Seq[T]): T = chisel3.util.PriorityMux(sel, Util.processArgs(in))
-  def apply[T <: Data](sel: Bits, in: Seq[T]): T = chisel3.util.PriorityMux(sel, in)
+  def apply[T <: Data](sel: Bits, in: Seq[T]): T      = chisel3.util.PriorityMux(sel, in)
 }
 
 ///** Creates a cascade of n Muxs to search for a key value.

--- a/src/test/scala/AsTypeOfTester.scala
+++ b/src/test/scala/AsTypeOfTester.scala
@@ -6,8 +6,8 @@ import fixedpoint._
 
 class AsTypeOfBundleTester extends Module {
   class MultiTypeBundle extends Bundle {
-    val u = UInt(4.W)
-    val s = SInt(4.W)
+    val u  = UInt(4.W)
+    val s  = SInt(4.W)
     val fp = FixedPoint(4.W, 3.BP)
   }
 

--- a/src/test/scala/AsTypeOfTester.scala
+++ b/src/test/scala/AsTypeOfTester.scala
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 import fixedpoint._
 
 class AsTypeOfBundleTester extends Module {
@@ -25,6 +26,6 @@ class AsTypeOfSpec extends ChiselFlatSpec {
   behavior.of("asTypeOf")
 
   it should "work with Bundles containing Bits Types" in {
-    assertTesterPasses { new AsTypeOfBundleTester }
+    simulate(new AsTypeOfBundleTester)(RunUntilFinished(1000))
   }
 }

--- a/src/test/scala/AsTypeOfTester.scala
+++ b/src/test/scala/AsTypeOfTester.scala
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import chisel3.testers.BasicTester
 import chisel3._
 import fixedpoint._
 
-class AsTypeOfBundleTester extends BasicTester {
+class AsTypeOfBundleTester extends Module {
   class MultiTypeBundle extends Bundle {
     val u = UInt(4.W)
     val s = SInt(4.W)

--- a/src/test/scala/BundleLiteralSpec.scala
+++ b/src/test/scala/BundleLiteralSpec.scala
@@ -2,6 +2,7 @@
 
 import chisel3._
 import chisel3.experimental.BundleLiterals._
+import chisel3.simulator.stimulus.RunUntilFinished
 import fixedpoint._
 
 class BundleLiteralSpec extends ChiselFlatSpec with Utils {
@@ -13,21 +14,19 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   }
 
   "bundle literals" should "pack" in {
-    assertTesterPasses {
-      new Module {
-        val longBundleLit =
-          (new LongBundle).Lit(_.a -> 0xdeaddeadbeefL.U, _.b -> (-0x0beef00dL).S(32.W), _.c -> 4.5.F(16.W, 4.BP))
-        longBundleLit.litOption should equal(
-          Some(
-            (BigInt(0xdeaddeadbeefL) << 48)
-              + (BigInt(0xffffffffL - 0xbeef00dL + 1) << 16)
-              + BigInt(72)
-          )
+    simulate(new Module {
+      val longBundleLit =
+        (new LongBundle).Lit(_.a -> 0xdeaddeadbeefL.U, _.b -> (-0x0beef00dL).S(32.W), _.c -> 4.5.F(16.W, 4.BP))
+      longBundleLit.litOption should equal(
+        Some(
+          (BigInt(0xdeaddeadbeefL) << 48)
+            + (BigInt(0xffffffffL - 0xbeef00dL + 1) << 16)
+            + BigInt(72)
         )
-        chisel3.assert(longBundleLit.asUInt === longBundleLit.litOption.get.U)
+      )
+      chisel3.assert(longBundleLit.asUInt === longBundleLit.litOption.get.U)
 
-        stop()
-      }
-    }
+      stop()
+    })(RunUntilFinished(1000))
   }
 }

--- a/src/test/scala/BundleLiteralSpec.scala
+++ b/src/test/scala/BundleLiteralSpec.scala
@@ -2,7 +2,6 @@
 
 import chisel3._
 import chisel3.experimental.BundleLiterals._
-import chisel3.testers.BasicTester
 import fixedpoint._
 
 class BundleLiteralSpec extends ChiselFlatSpec with Utils {
@@ -15,7 +14,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
 
   "bundle literals" should "pack" in {
     assertTesterPasses {
-      new BasicTester {
+      new Module {
         val longBundleLit =
           (new LongBundle).Lit(_.a -> 0xdeaddeadbeefL.U, _.b -> (-0x0beef00dL).S(32.W), _.c -> 4.5.F(16.W, 4.BP))
         longBundleLit.litOption should equal(

--- a/src/test/scala/ChiselSpec.scala
+++ b/src/test/scala/ChiselSpec.scala
@@ -42,10 +42,10 @@ abstract class ChiselPropSpec extends AnyPropSpec with ScalaCheckPropertyChecks 
 
   // Generator for positive (ascending or descending) ranges.
   def posRange: Gen[Range] = for {
-    dir <- Gen.oneOf(true, false)
+    dir  <- Gen.oneOf(true, false)
     step <- Gen.choose(1, 3)
-    m <- Gen.choose(1, 10)
-    n <- Gen.choose(1, 10)
+    m    <- Gen.choose(1, 10)
+    n    <- Gen.choose(1, 10)
   } yield {
     if (dir) {
       Range(m, (m + n) * step, step)
@@ -104,7 +104,7 @@ trait Utils {
     */
   def grabStdOutErr[T](thunk: => T): (String, String, T) = {
     val stdout, stderr = new ByteArrayOutputStream()
-    val ret = scala.Console.withOut(stdout) { scala.Console.withErr(stderr) { thunk } }
+    val ret            = scala.Console.withOut(stdout) { scala.Console.withErr(stderr) { thunk } }
     (stdout.toString, stderr.toString, ret)
   }
 
@@ -113,7 +113,7 @@ trait Utils {
     * @return a tuple containing LOGGED, and what the thunk returns
     */
   def grabLog[T](thunk: => T): (String, T) = {
-    val baos = new ByteArrayOutputStream()
+    val baos   = new ByteArrayOutputStream()
     val stream = new PrintStream(baos, true, "utf-8")
     val ret = Logger.makeScope(Nil) {
       Logger.setOutput(stream)

--- a/src/test/scala/ChiselSpec.scala
+++ b/src/test/scala/ChiselSpec.scala
@@ -1,14 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import _root_.logger.Logger
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.stage.{ChiselGeneratorAnnotation, PrintFullStackTraceAnnotation}
 import circt.stage.{CIRCTTarget, CIRCTTargetAnnotation, ChiselStage}
-//import firrtl.annotations.Annotation
-//import firrtl.ir.Circuit
-//import firrtl.util.BackendCompilationUtilities
-//import firrtl.{AnnotationSeq, EmittedVerilogCircuitAnnotation}
 import org.scalacheck._
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -108,20 +103,6 @@ trait Utils {
     (stdout.toString, stderr.toString, ret)
   }
 
-  /** Run some Scala thunk and return all logged messages as Strings
-    * @param thunk some Scala code
-    * @return a tuple containing LOGGED, and what the thunk returns
-    */
-  def grabLog[T](thunk: => T): (String, T) = {
-    val baos   = new ByteArrayOutputStream()
-    val stream = new PrintStream(baos, true, "utf-8")
-    val ret = Logger.makeScope(Nil) {
-      Logger.setOutput(stream)
-      thunk
-    }
-    (baos.toString, ret)
-  }
-
   /** Encodes a System.exit exit code
     * @param status the exit code
     */
@@ -191,32 +172,6 @@ trait Utils {
 //      System.setSecurityManager(null)
 //    }
 //  }
-
-  /** A tester which runs generator and uses an aspect to check the returned object
-    * @param gen function to generate a Chisel module
-    * @param f a function to check the Chisel module
-    * @tparam T the Chisel module class
-    */
-  def aspectTest[T <: RawModule](gen: () => T)(f: T => Unit)(implicit scalaMajorVersion: Int): Unit = {
-    // Runs chisel stage
-    def run[T <: RawModule](gen: () => T /*, annotations: AnnotationSeq*/ ): Unit /*AnnotationSeq*/ = {
-      new ChiselStage().run(
-        Seq(
-          ChiselGeneratorAnnotation(gen),
-          CIRCTTargetAnnotation(CIRCTTarget.CHIRRTL),
-          PrintFullStackTraceAnnotation
-        ) // ++ annotations
-      )
-    }
-    // Creates a wrapping aspect to contain checking function
-//    case object BuiltAspect extends Aspect[T] {
-//      override def toAnnotation(top: T): AnnotationSeq = { f(top); Nil }
-//    }
-    val currentMajorVersion = scala.util.Properties.versionNumberString.split('.')(1).toInt
-    if (currentMajorVersion >= scalaMajorVersion) {
-      run(gen /*, Seq(BuiltAspect)*/ )
-    }
-  }
 
   /** Run some code and rethrow an exception with a specific type if an exception of that type occurs anywhere in the
     * stack trace.

--- a/src/test/scala/ConnectSpec.scala
+++ b/src/test/scala/ConnectSpec.scala
@@ -3,6 +3,7 @@
 import chisel3.experimental.Analog
 import circt.stage.ChiselStage
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 import fixedpoint._
 
 class CrossConnects(inType: Data, outType: Data) extends Module {
@@ -35,8 +36,8 @@ class ConnectSpec extends ChiselPropSpec with Utils {
     }
   }
   property("FixedPoint := FixedPoint should succeed") {
-    assertTesterPasses { new CrossConnectTester(FixedPoint(16.W, 8.BP), FixedPoint(16.W, 8.BP)) }
-    assertTesterPasses { new CrossConnectTester(FixedPoint(2.W, 14.BP), FixedPoint(8.W, 6.BP)) }
+    simulate(new CrossConnectTester(FixedPoint(16.W, 8.BP), FixedPoint(16.W, 8.BP)))(RunUntilFinished(1000))
+    simulate(new CrossConnectTester(FixedPoint(2.W, 14.BP), FixedPoint(8.W, 6.BP)))(RunUntilFinished(1000))
   }
   property("FixedPoint := SInt should fail") {
     intercept[ChiselException] {

--- a/src/test/scala/ConnectSpec.scala
+++ b/src/test/scala/ConnectSpec.scala
@@ -2,7 +2,6 @@
 
 import chisel3.experimental.Analog
 import circt.stage.ChiselStage
-import chisel3.testers.BasicTester
 import chisel3._
 import fixedpoint._
 
@@ -14,7 +13,7 @@ class CrossConnects(inType: Data, outType: Data) extends Module {
   io.out := io.in
 }
 
-class CrossConnectTester(inType: Data, outType: Data) extends BasicTester {
+class CrossConnectTester(inType: Data, outType: Data) extends Module {
   val dut = Module(new CrossConnects(inType, outType))
   dut.io := DontCare
   stop()

--- a/src/test/scala/ConnectSpec.scala
+++ b/src/test/scala/ConnectSpec.scala
@@ -8,7 +8,7 @@ import fixedpoint._
 
 class CrossConnects(inType: Data, outType: Data) extends Module {
   val io = IO(new Bundle {
-    val in = Input(inType)
+    val in  = Input(inType)
     val out = Output(outType)
   })
   io.out := io.in

--- a/src/test/scala/DataEqualitySpec.scala
+++ b/src/test/scala/DataEqualitySpec.scala
@@ -2,7 +2,6 @@
 
 import chisel3._
 import chisel3.experimental.BundleLiterals._
-import chisel3.testers.BasicTester
 import fixedpoint._
 
 class EqualityModule(lhsGen: => Data, rhsGen: => Data) extends Module {
@@ -14,7 +13,7 @@ class EqualityModule(lhsGen: => Data, rhsGen: => Data) extends Module {
   out := lhs === rhs
 }
 
-class EqualityTester(lhsGen: => Data, rhsGen: => Data) extends BasicTester {
+class EqualityTester(lhsGen: => Data, rhsGen: => Data) extends Module {
   val module = Module(new EqualityModule(lhsGen, rhsGen))
 
   assert(module.out)
@@ -51,9 +50,12 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
     }
   }
   it should "fail with differing values" in {
-    assertTesterFails {
-      new EqualityTester(4.5.F(16.W, 4.BP), 4.6.F(16.W, 4.BP))
+    val e = the[RuntimeException] thrownBy {
+      assertTesterFails {
+        new EqualityTester(4.5.F(16.W, 4.BP), 4.6.F(16.W, 4.BP))
+      }
     }
+    e.getMessage should include("Assertion failed at DataEqualitySpec")
   }
 
   behavior.of("Bundle === Bundle")

--- a/src/test/scala/DataEqualitySpec.scala
+++ b/src/test/scala/DataEqualitySpec.scala
@@ -2,6 +2,7 @@
 
 import chisel3._
 import chisel3.experimental.BundleLiterals._
+import chisel3.simulator.stimulus.RunUntilFinished
 import fixedpoint._
 
 class EqualityModule(lhsGen: => Data, rhsGen: => Data) extends Module {
@@ -45,15 +46,11 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
 
   behavior.of("FixedPoint === FixedPoint")
   it should "pass with equal values" in {
-    assertTesterPasses {
-      new EqualityTester(4.5.F(16.W, 4.BP), 4.5.F(16.W, 4.BP))
-    }
+    simulate(new EqualityTester(4.5.F(16.W, 4.BP), 4.5.F(16.W, 4.BP)))(RunUntilFinished(1000))
   }
   it should "fail with differing values" in {
     val e = the[RuntimeException] thrownBy {
-      assertTesterFails {
-        new EqualityTester(4.5.F(16.W, 4.BP), 4.6.F(16.W, 4.BP))
-      }
+      simulate(new EqualityTester(4.5.F(16.W, 4.BP), 4.6.F(16.W, 4.BP)))(RunUntilFinished(1000))
     }
     e.getMessage should include("Assertion failed at DataEqualitySpec")
   }
@@ -61,7 +58,7 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
   behavior.of("Bundle === Bundle")
   it should "throw a ChiselException with differing runtime types" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      assertTesterFails {
+      simulate(
         new EqualityTester(
           (new RuntimeSensitiveBundle(new MyBundle)).Lit(
             _.a -> 1.U,
@@ -80,7 +77,7 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
             )
           )
         )
-      }
+      )(RunUntilFinished(1000))
     }).getMessage should include("Runtime types differ")
   }
 }

--- a/src/test/scala/DataEqualitySpec.scala
+++ b/src/test/scala/DataEqualitySpec.scala
@@ -40,7 +40,7 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
   }
 
   class RuntimeSensitiveBundle(gen: => Bundle) extends Bundle {
-    val a = UInt(8.W)
+    val a         = UInt(8.W)
     val b: Bundle = gen
   }
 

--- a/src/test/scala/FixedPointSpec.scala
+++ b/src/test/scala/FixedPointSpec.scala
@@ -76,9 +76,9 @@ class FixedPointFromBitsTester extends BasicTester {
   val f6bp0 = 6.0.F(0.BP)
   val f6bp2 = 6.0.F(2.BP)
 
-  val f1bp5shiftleft2 = Wire(FixedPoint(UnknownWidth(), BinaryPoint()))
-  val f6bp0shiftright2 = Wire(FixedPoint(UnknownWidth(), BinaryPoint()))
-  val f6bp2shiftright2 = Wire(FixedPoint(UnknownWidth(), BinaryPoint()))
+  val f1bp5shiftleft2 = Wire(FixedPoint(UnknownWidth, BinaryPoint()))
+  val f6bp0shiftright2 = Wire(FixedPoint(UnknownWidth, BinaryPoint()))
+  val f6bp2shiftright2 = Wire(FixedPoint(UnknownWidth, BinaryPoint()))
 
   f1bp5shiftleft2 := f1bp5 << 2
   f6bp0shiftright2 := f6bp0 >> 2

--- a/src/test/scala/FixedPointSpec.scala
+++ b/src/test/scala/FixedPointSpec.scala
@@ -177,7 +177,7 @@ class FixedPointFloorTester
       _.floor,
       Seq(
         -4.75.F(8.W, 2.BP) -> -5.0.F(8.W, 2.BP),
-        55.5.F(8.W, 2.BP)  -> 55.0.F(8.W, 2.BP),
+        23.5.F(8.W, 2.BP)  -> 23.0.F(8.W, 2.BP),
         -4.0.F(2.BP)       -> -4.0.F(2.BP),
         0.125.F(8.W, 4.BP) -> 0.0.F(8.W, 4.BP),
         3.0.F(0.BP)        -> 3.0.F(0.BP),
@@ -194,7 +194,7 @@ class FixedPointCeilTester
       _.ceil,
       Seq(
         -4.75.F(8.W, 2.BP) -> -4.0.F(8.W, 2.BP),
-        55.5.F(8.W, 2.BP)  -> 56.0.F(8.W, 2.BP),
+        23.5.F(8.W, 2.BP)  -> 24.0.F(8.W, 2.BP),
         -4.0.F(2.BP)       -> -4.0.F(2.BP),
         0.125.F(8.W, 4.BP) -> 1.0.F(8.W, 4.BP),
         3.0.F(0.BP)        -> 3.0.F(0.BP),

--- a/src/test/scala/FixedPointSpec.scala
+++ b/src/test/scala/FixedPointSpec.scala
@@ -2,6 +2,7 @@
 
 import circt.stage.ChiselStage
 import chisel3.{Mux => _, _}
+import chisel3.simulator.stimulus.RunUntilFinished
 import fixedpoint._
 import fixedpoint.shadow.Mux
 import org.scalatest.flatspec.AnyFlatSpec
@@ -225,13 +226,13 @@ class FixedPointRoundTester
 
 class FixedPointSpec extends ChiselPropSpec with Utils {
   property("should allow set binary point") {
-    assertTesterPasses { new SBPTester }
+    simulate(new SBPTester)(RunUntilFinished(1000))
   }
   property("should allow fromBits") {
-    assertTesterPasses { new FixedPointFromBitsTester }
+    simulate(new FixedPointFromBitsTester)(RunUntilFinished(1000))
   }
   property("should mux different widths and binary points") {
-    assertTesterPasses { new FixedPointMuxTester }
+    simulate(new FixedPointMuxTester)(RunUntilFinished(1000))
   }
   property("Negative shift amounts are invalid") {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
@@ -239,19 +240,19 @@ class FixedPointSpec extends ChiselPropSpec with Utils {
     }
   }
   property("Bit extraction on literals should work for all non-negative indices") {
-    assertTesterPasses(new FixedPointLitExtractTester)
+    simulate(new FixedPointLitExtractTester)(RunUntilFinished(1000))
   }
 
   property("Floor operation works") {
-    assertTesterPasses { new FixedPointFloorTester }
+    simulate(new FixedPointFloorTester)(RunUntilFinished(1000))
   }
 
   property("Ceil operation works") {
-    assertTesterPasses { new FixedPointCeilTester }
+    simulate(new FixedPointCeilTester)(RunUntilFinished(1000))
   }
 
   property("Round operation works") {
-    assertTesterPasses { new FixedPointRoundTester }
+    simulate(new FixedPointRoundTester)(RunUntilFinished(1000))
   }
 
   property("Negative binary point is invalid") {

--- a/src/test/scala/FixedPointSpec.scala
+++ b/src/test/scala/FixedPointSpec.scala
@@ -13,18 +13,18 @@ class FixedPointLiteralSpec extends AnyFlatSpec with Matchers {
 
   they should "allow conversion between doubles and the bigints needed to represent them" in {
     val initialDouble = 0.125
-    val bigInt = FixedPoint.toBigInt(initialDouble, 4)
-    val finalDouble = FixedPoint.toDouble(bigInt, 4)
+    val bigInt        = FixedPoint.toBigInt(initialDouble, 4)
+    val finalDouble   = FixedPoint.toDouble(bigInt, 4)
 
     initialDouble should be(finalDouble)
   }
 
   they should "have their literals support to double and to BigDecimal" in {
-    val d = -7.125
+    val d    = -7.125
     val lit1 = d.F(3.BP)
     lit1.litToDouble should be(d)
 
-    val d2 = BigDecimal("1232123213131123.125")
+    val d2   = BigDecimal("1232123213131123.125")
     val lit2 = d2.F(3.BP)
     lit2.litToBigDecimal should be(d2)
 
@@ -40,19 +40,19 @@ class FixedPointFromBitsTester extends Module {
   val uint = 3.U(4.W)
   val sint = (-3).S
 
-  val fp = FixedPoint.fromDouble(3.0, 4.W, 0.BP)
-  val fp_tpe = FixedPoint(4.W, 1.BP)
+  val fp          = FixedPoint.fromDouble(3.0, 4.W, 0.BP)
+  val fp_tpe      = FixedPoint(4.W, 1.BP)
   val uint_result = FixedPoint.fromDouble(1.5, 4.W, 1.BP)
   val sint_result = FixedPoint.fromDouble(-1.5, 4.W, 1.BP)
-  val fp_result = FixedPoint.fromDouble(1.5, 4.W, 1.BP)
+  val fp_result   = FixedPoint.fromDouble(1.5, 4.W, 1.BP)
 
   val uint2fp = uint.asTypeOf(fp_tpe)
   val sint2fp = sint.asTypeOf(fp_tpe)
-  val fp2fp = fp.asTypeOf(fp_tpe)
+  val fp2fp   = fp.asTypeOf(fp_tpe)
 
   val uintToFp = uint.asFixedPoint(1.BP)
   val sintToFp = sint.asFixedPoint(1.BP)
-  val fpToFp = fp.asFixedPoint(1.BP)
+  val fpToFp   = fp.asFixedPoint(1.BP)
 
   val negativefp = (-3.5).F(4.BP)
   val positivefp = 3.5.F(4.BP)
@@ -76,11 +76,11 @@ class FixedPointFromBitsTester extends Module {
   val f6bp0 = 6.0.F(0.BP)
   val f6bp2 = 6.0.F(2.BP)
 
-  val f1bp5shiftleft2 = Wire(FixedPoint(UnknownWidth, BinaryPoint()))
+  val f1bp5shiftleft2  = Wire(FixedPoint(UnknownWidth, BinaryPoint()))
   val f6bp0shiftright2 = Wire(FixedPoint(UnknownWidth, BinaryPoint()))
   val f6bp2shiftright2 = Wire(FixedPoint(UnknownWidth, BinaryPoint()))
 
-  f1bp5shiftleft2 := f1bp5 << 2
+  f1bp5shiftleft2  := f1bp5 << 2
   f6bp0shiftright2 := f6bp0 >> 2
   f6bp2shiftright2 := f6bp2 >> 2
 
@@ -95,10 +95,10 @@ class FixedPointFromBitsTester extends Module {
 }
 
 class FixedPointMuxTester extends Module {
-  val largeWidthLowPrecision = 6.0.F(4.W, 0.BP)
-  val smallWidthHighPrecision = 0.25.F(2.W, 2.BP)
+  val largeWidthLowPrecision   = 6.0.F(4.W, 0.BP)
+  val smallWidthHighPrecision  = 0.25.F(2.W, 2.BP)
   val unknownWidthLowPrecision = 6.0.F(0.BP)
-  val unknownFixed = Wire(FixedPoint())
+  val unknownFixed             = Wire(FixedPoint())
   unknownFixed := smallWidthHighPrecision
 
   assert(Mux(true.B, largeWidthLowPrecision, smallWidthHighPrecision) === 6.0.F(0.BP))
@@ -111,7 +111,7 @@ class FixedPointMuxTester extends Module {
 
 class SBP extends Module {
   val io = IO(new Bundle {
-    val in = Input(FixedPoint(6.W, 2.BP))
+    val in  = Input(FixedPoint(6.W, 2.BP))
     val out = Output(FixedPoint(4.W, 0.BP))
   })
   io.out := io.in.setBinaryPoint(0)
@@ -161,8 +161,7 @@ class FixedPointLitExtractTester extends Module {
   stop()
 }
 
-class FixedPointUnaryFuncTester(f: FixedPoint => FixedPoint, inExpected: Seq[(FixedPoint, FixedPoint)])
-    extends Module {
+class FixedPointUnaryFuncTester(f: FixedPoint => FixedPoint, inExpected: Seq[(FixedPoint, FixedPoint)]) extends Module {
   inExpected.foreach {
     case (in, expected) =>
       val out = f(in)
@@ -178,13 +177,13 @@ class FixedPointFloorTester
       _.floor,
       Seq(
         -4.75.F(8.W, 2.BP) -> -5.0.F(8.W, 2.BP),
-        55.5.F(8.W, 2.BP) -> 55.0.F(8.W, 2.BP),
-        -4.0.F(2.BP) -> -4.0.F(2.BP),
+        55.5.F(8.W, 2.BP)  -> 55.0.F(8.W, 2.BP),
+        -4.0.F(2.BP)       -> -4.0.F(2.BP),
         0.125.F(8.W, 4.BP) -> 0.0.F(8.W, 4.BP),
-        3.0.F(0.BP) -> 3.0.F(0.BP),
+        3.0.F(0.BP)        -> 3.0.F(0.BP),
         // Overflow to zero when binaryPoint >= width
-        0.25.F(2.W, 2.BP) -> 0.F(0.BP),
-        -0.5.F(2.W, 2.BP) -> 0.F(0.BP),
+        0.25.F(2.W, 2.BP)   -> 0.F(0.BP),
+        -0.5.F(2.W, 2.BP)   -> 0.F(0.BP),
         0.0625.F(2.W, 4.BP) -> 0.F(0.BP),
         -0.125.F(2.W, 4.BP) -> 0.F(0.BP)
       )
@@ -195,13 +194,13 @@ class FixedPointCeilTester
       _.ceil,
       Seq(
         -4.75.F(8.W, 2.BP) -> -4.0.F(8.W, 2.BP),
-        55.5.F(8.W, 2.BP) -> 56.0.F(8.W, 2.BP),
-        -4.0.F(2.BP) -> -4.0.F(2.BP),
+        55.5.F(8.W, 2.BP)  -> 56.0.F(8.W, 2.BP),
+        -4.0.F(2.BP)       -> -4.0.F(2.BP),
         0.125.F(8.W, 4.BP) -> 1.0.F(8.W, 4.BP),
-        3.0.F(0.BP) -> 3.0.F(0.BP),
+        3.0.F(0.BP)        -> 3.0.F(0.BP),
         // Overflow to zero when binaryPoint >= width
-        0.25.F(2.W, 2.BP) -> 0.F(0.BP),
-        -0.5.F(2.W, 2.BP) -> 0.F(0.BP),
+        0.25.F(2.W, 2.BP)   -> 0.F(0.BP),
+        -0.5.F(2.W, 2.BP)   -> 0.F(0.BP),
         0.0625.F(2.W, 4.BP) -> 0.F(0.BP),
         -0.125.F(2.W, 4.BP) -> 0.F(0.BP)
       )
@@ -212,13 +211,13 @@ class FixedPointRoundTester
       _.round,
       Seq(
         -4.75.F(8.W, 2.BP) -> -5.0.F(8.W, 2.BP),
-        25.5.F(8.W, 2.BP) -> 26.0.F(8.W, 2.BP),
-        -4.0.F(2.BP) -> -4.0.F(2.BP),
+        25.5.F(8.W, 2.BP)  -> 26.0.F(8.W, 2.BP),
+        -4.0.F(2.BP)       -> -4.0.F(2.BP),
         0.125.F(8.W, 3.BP) -> 0.0.F(8.W, 3.BP),
-        3.0.F(0.BP) -> 3.0.F(0.BP),
+        3.0.F(0.BP)        -> 3.0.F(0.BP),
         // Overflow to zero when binaryPoint >= width
-        0.25.F(2.W, 2.BP) -> 0.F(0.BP),
-        -0.5.F(2.W, 2.BP) -> 0.F(0.BP),
+        0.25.F(2.W, 2.BP)   -> 0.F(0.BP),
+        -0.5.F(2.W, 2.BP)   -> 0.F(0.BP),
         0.0625.F(2.W, 4.BP) -> 0.F(0.BP),
         -0.125.F(2.W, 4.BP) -> 0.F(0.BP)
       )

--- a/src/test/scala/FixedPointSpec.scala
+++ b/src/test/scala/FixedPointSpec.scala
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import circt.stage.ChiselStage
-import chisel3.testers.BasicTester
 import chisel3.{Mux => _, _}
 import fixedpoint._
 import fixedpoint.shadow.Mux
@@ -36,7 +35,7 @@ class FixedPointLiteralSpec extends AnyFlatSpec with Matchers {
 }
 
 //noinspection TypeAnnotation,EmptyParenMethodAccessedAsParameterless
-class FixedPointFromBitsTester extends BasicTester {
+class FixedPointFromBitsTester extends Module {
   val uint = 3.U(4.W)
   val sint = (-3).S
 
@@ -94,7 +93,7 @@ class FixedPointFromBitsTester extends BasicTester {
   stop()
 }
 
-class FixedPointMuxTester extends BasicTester {
+class FixedPointMuxTester extends Module {
   val largeWidthLowPrecision = 6.0.F(4.W, 0.BP)
   val smallWidthHighPrecision = 0.25.F(2.W, 2.BP)
   val unknownWidthLowPrecision = 6.0.F(0.BP)
@@ -117,7 +116,7 @@ class SBP extends Module {
   io.out := io.in.setBinaryPoint(0)
 }
 
-class SBPTester extends BasicTester {
+class SBPTester extends Module {
   val dut = Module(new SBP)
   dut.io.in := 3.75.F(2.BP)
 
@@ -137,7 +136,7 @@ class NegativeShift(t: => Bits) extends Module {
   Reg(t) >> -1
 }
 
-class FixedPointLitExtractTester extends BasicTester {
+class FixedPointLitExtractTester extends Module {
   assert(-4.75.F(2.BP)(1) === false.B)
   assert(-4.75.F(2.BP)(2) === true.B)
   assert(-4.75.F(2.BP)(100) === true.B)
@@ -162,7 +161,7 @@ class FixedPointLitExtractTester extends BasicTester {
 }
 
 class FixedPointUnaryFuncTester(f: FixedPoint => FixedPoint, inExpected: Seq[(FixedPoint, FixedPoint)])
-    extends BasicTester {
+    extends Module {
   inExpected.foreach {
     case (in, expected) =>
       val out = f(in)
@@ -256,8 +255,8 @@ class FixedPointSpec extends ChiselPropSpec with Utils {
   }
 
   property("Negative binary point is invalid") {
-    assertThrows[IllegalArgumentException](new BasicTester { 2.F((-1).BP) })
-    assertThrows[IllegalArgumentException](new BasicTester { 1.F(0.BP).setBinaryPoint(-1) })
-    assertThrows[IllegalArgumentException](new BasicTester { FixedPoint(4.W, (-2).BP) })
+    assertThrows[IllegalArgumentException](new Module { 2.F((-1).BP) })
+    assertThrows[IllegalArgumentException](new Module { 1.F(0.BP).setBinaryPoint(-1) })
+    assertThrows[IllegalArgumentException](new Module { FixedPoint(4.W, (-2).BP) })
   }
 }

--- a/src/test/scala/LiteralExtractorSpec.scala
+++ b/src/test/scala/LiteralExtractorSpec.scala
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import chisel3.experimental.BundleLiterals._
-import chisel3.testers.BasicTester
 import chisel3._
 import fixedpoint._
 
@@ -62,7 +61,7 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       val x = FixedPoint(8.W, 4.BP)
     }
 
-    class LitInsideOutsideTester(outsideLiteral: InsideBundle) extends BasicTester {
+    class LitInsideOutsideTester(outsideLiteral: InsideBundle) extends Module {
       val insideLiteral = (new InsideBundle).Lit(_.x -> 6.125.F(8.W, 4.BP))
 
       // the following errors with "assertion failed"

--- a/src/test/scala/LiteralExtractorSpec.scala
+++ b/src/test/scala/LiteralExtractorSpec.scala
@@ -41,7 +41,7 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       NumBP.toDouble(BigInt("1" * 54, 2), 0.BP) // this only works if number takes less than 54 bits
     }
 
-    val bigInt108 = BigInt("1" * 108, 2)
+    val bigInt108  = BigInt("1" * 108, 2)
     val bigDecimal = Num.toBigDecimal(bigInt108, 2)
 
     val bigIntFromBigDecimal = Num.toBigInt(bigDecimal, 2)

--- a/src/test/scala/LiteralExtractorSpec.scala
+++ b/src/test/scala/LiteralExtractorSpec.scala
@@ -2,6 +2,7 @@
 
 import chisel3.experimental.BundleLiterals._
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 import fixedpoint._
 
 class LiteralExtractorSpec extends ChiselFlatSpec {
@@ -79,7 +80,7 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
     }
 
     val outsideLiteral = (new InsideBundle).Lit(_.x -> 6.125.F(8.W, 4.BP))
-    assertTesterPasses { new LitInsideOutsideTester(outsideLiteral) }
+    simulate(new LitInsideOutsideTester(outsideLiteral))(RunUntilFinished(1000))
 
   }
 }

--- a/src/test/scala/OneHotMuxSpec.scala
+++ b/src/test/scala/OneHotMuxSpec.scala
@@ -35,7 +35,7 @@ class FixedPointOneHotTester extends Module {
   out := Mux1H(
     Seq(
       false.B -> (-1.5).F(8.W, 1.BP),
-      true.B -> (-2.25).F(8.W, 2.BP),
+      true.B  -> (-2.25).F(8.W, 2.BP),
       false.B -> (-4.125).F(8.W, 3.BP),
       false.B -> (-11.625).F(8.W, 3.BP)
     )
@@ -52,7 +52,7 @@ class AllSameFixedPointOneHotTester extends Module {
   out := Mux1H(
     Seq(
       false.B -> (-1.5).F(12.W, 3.BP),
-      true.B -> (-2.25).F(12.W, 3.BP),
+      true.B  -> (-2.25).F(12.W, 3.BP),
       false.B -> (-4.125).F(12.W, 3.BP),
       false.B -> (-11.625).F(12.W, 3.BP)
     )
@@ -73,7 +73,7 @@ class Agg1 extends Bundle {
 
 object Agg1 extends HasMakeLit[Agg1] {
   def makeLit(n: Int): Agg1 = {
-    val x = n.toDouble / 4.0
+    val x                                            = n.toDouble / 4.0
     val (d: Double, e: Double, f: Double, g: Double) = (x, x * 2.0, x * 3.0, x * 4.0)
 
     val w = Wire(new Agg1)
@@ -94,7 +94,7 @@ class Agg2 extends Bundle {
 
 object Agg2 extends HasMakeLit[Agg2] {
   def makeLit(n: Int): Agg2 = {
-    val x = n.toDouble / 4.0
+    val x                                            = n.toDouble / 4.0
     val (d: Double, e: Double, f: Double, g: Double) = (x, x * 2.0, x * 3.0, x * 4.0)
 
     val w = Wire(new Agg2)
@@ -125,11 +125,11 @@ trait HasMakeLit[T] {
 class ParameterizedAggregateOneHot[T <: Data](valGen: HasMakeLit[T], outGen: T) extends Module {
   val io = IO(new Bundle {
     val selectors = Input(Vec(4, Bool()))
-    val out = Output(outGen)
+    val out       = Output(outGen)
   })
 
   val values = (0 until 4).map { n => valGen.makeLit(n) }
-  val terms = io.selectors.zip(values)
+  val terms  = io.selectors.zip(values)
   io.out := Mux1H(terms)
 }
 
@@ -142,26 +142,26 @@ class Bundle1 extends Bundle {
 
 class InferredWidthAggregateOneHotTester extends Module {
   val b0 = Wire(new Bundle1)
-  b0.a := -0.25.F(2.BP)
+  b0.a   := -0.25.F(2.BP)
   b0.b.c := -0.125.F(3.BP)
 
   val b1 = Wire(new Bundle1)
-  b1.a := -0.0625.F(3.BP)
+  b1.a   := -0.0625.F(3.BP)
   b1.b.c := -0.03125.F(4.BP)
 
   val b2 = Wire(new Bundle1)
-  b2.a := -0.015625.F(5.BP)
+  b2.a   := -0.015625.F(5.BP)
   b2.b.c := -0.0078125.F(6.BP)
 
   val b3 = Wire(new Bundle1)
-  b3.a := -0.0078125.F(7.BP)
+  b3.a   := -0.0078125.F(7.BP)
   b3.b.c := -0.00390625.F(8.BP)
 
   val o1 = Mux1H(
     Seq(
       false.B -> b0,
       false.B -> b1,
-      true.B -> b2,
+      true.B  -> b2,
       false.B -> b3
     )
   )
@@ -172,7 +172,7 @@ class InferredWidthAggregateOneHotTester extends Module {
   val o2 = Mux1H(
     Seq(
       false.B -> b0,
-      true.B -> b1,
+      true.B  -> b1,
       false.B -> b2,
       false.B -> b3
     )
@@ -200,26 +200,26 @@ class Bundle3 extends Bundle {
 
 class DifferentBundleOneHotTester extends Module {
   val b0 = Wire(new Bundle2)
-  b0.a := -0.25.F(2.BP)
+  b0.a   := -0.25.F(2.BP)
   b0.b.c := -0.125.F(3.BP)
 
   val b1 = Wire(new Bundle2)
-  b1.a := -0.0625.F(3.BP)
+  b1.a   := -0.0625.F(3.BP)
   b1.b.c := -0.03125.F(4.BP)
 
   val b2 = Wire(new Bundle3)
-  b2.a := -0.015625.F(5.BP)
+  b2.a   := -0.015625.F(5.BP)
   b2.b.c := -0.0078125.F(6.BP)
 
   val b3 = Wire(new Bundle3)
-  b3.a := -0.0078125.F(7.BP)
+  b3.a   := -0.0078125.F(7.BP)
   b3.b.c := -0.00390625.F(8.BP)
 
   val o1 = Mux1H(
     Seq(
       false.B -> b0,
       false.B -> b1,
-      true.B -> b2,
+      true.B  -> b2,
       false.B -> b3
     )
   )

--- a/src/test/scala/OneHotMuxSpec.scala
+++ b/src/test/scala/OneHotMuxSpec.scala
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import chisel3.ChiselException
-import chisel3.testers.BasicTester
 import chisel3._
 import fixedpoint._
 import fixedpoint.shadow.Mux1H
@@ -30,7 +29,7 @@ class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselRunners {
   }
 }
 
-class FixedPointOneHotTester extends BasicTester {
+class FixedPointOneHotTester extends Module {
   val out = Wire(FixedPoint(8.W, 4.BP))
 
   out := Mux1H(
@@ -47,7 +46,7 @@ class FixedPointOneHotTester extends BasicTester {
   stop()
 }
 
-class AllSameFixedPointOneHotTester extends BasicTester {
+class AllSameFixedPointOneHotTester extends Module {
   val out = Wire(FixedPoint(12.W, 3.BP))
 
   out := Mux1H(
@@ -107,7 +106,7 @@ object Agg2 extends HasMakeLit[Agg2] {
   }
 }
 
-class ParameterizedAggregateOneHotTester extends BasicTester {
+class ParameterizedAggregateOneHotTester extends Module {
   val values = (0 until 4).map { n => Agg1.makeLit(n) }
   for ((v, i) <- values.zipWithIndex) {
     val dut = Module(new ParameterizedAggregateOneHot(Agg1, new Agg1))
@@ -141,7 +140,7 @@ class Bundle1 extends Bundle {
   }
 }
 
-class InferredWidthAggregateOneHotTester extends BasicTester {
+class InferredWidthAggregateOneHotTester extends Module {
   val b0 = Wire(new Bundle1)
   b0.a := -0.25.F(2.BP)
   b0.b.c := -0.125.F(3.BP)
@@ -199,7 +198,7 @@ class Bundle3 extends Bundle {
   }
 }
 
-class DifferentBundleOneHotTester extends BasicTester {
+class DifferentBundleOneHotTester extends Module {
   val b0 = Wire(new Bundle2)
   b0.a := -0.25.F(2.BP)
   b0.b.c := -0.125.F(3.BP)

--- a/src/test/scala/OneHotMuxSpec.scala
+++ b/src/test/scala/OneHotMuxSpec.scala
@@ -1,30 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import chisel3.ChiselException
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 import fixedpoint._
 import fixedpoint.shadow.Mux1H
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselRunners {
+class OneHotMuxSpec extends ChiselFreeSpec {
   "simple one hot mux with fixed point should work" in {
-    assertTesterPasses(new FixedPointOneHotTester)
+    simulate(new FixedPointOneHotTester)(RunUntilFinished(1000))
   }
   "simple one hot mux with all same fixed point should work" in {
-    assertTesterPasses(new AllSameFixedPointOneHotTester)
+    simulate(new AllSameFixedPointOneHotTester)(RunUntilFinished(1000))
   }
   "simple one hot mux with all same parameterized aggregates containing fixed values should work" in {
-    assertTesterPasses(new ParameterizedAggregateOneHotTester)
+    simulate(new ParameterizedAggregateOneHotTester)(RunUntilFinished(1000))
   }
   "simple one hot mux with all aggregates containing inferred width fixed values should NOT work" in {
     intercept[ChiselException] {
-      assertTesterPasses(new InferredWidthAggregateOneHotTester)
+      simulate(new InferredWidthAggregateOneHotTester)(RunUntilFinished(1000))
     }
   }
   "simple one hot mux with all fixed width bundles but with different bundles should Not work" in {
     intercept[IllegalArgumentException] {
-      assertTesterPasses(new DifferentBundleOneHotTester)
+      simulate(new DifferentBundleOneHotTester)(RunUntilFinished(1000))
     }
   }
 }

--- a/src/test/scala/VecLiteralSpec.scala
+++ b/src/test/scala/VecLiteralSpec.scala
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import chisel3.experimental.VecLiterals._
-import chisel3.testers.BasicTester
 import chisel3._
 import fixedpoint._
 
@@ -11,7 +10,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
   //TODO: decide what behavior here should be
   "This doesn't work should it" ignore {
     assertTesterPasses {
-      new BasicTester {
+      new Module {
         def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
 
         val vecWire1 = Wire(Output(vecFactory))
@@ -30,7 +29,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "partially initialized Vec literals should assign" in {
     assertTesterPasses {
-      new BasicTester {
+      new Module {
         def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
 
         val vecWire1 = Wire(Output(vecFactory))

--- a/src/test/scala/VecLiteralSpec.scala
+++ b/src/test/scala/VecLiteralSpec.scala
@@ -8,15 +8,15 @@ import fixedpoint._
 import scala.language.reflectiveCalls
 
 class VecLiteralSpec extends ChiselFreeSpec with Utils {
-  //TODO: decide what behavior here should be
+  // TODO: decide what behavior here should be
   "This doesn't work should it" ignore {
     simulate(
       new Module {
         def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
 
         val vecWire1 = Wire(Output(vecFactory))
-        val vecLit1 = vecFactory.Lit(0 -> (1.5).F(8.W, 4.BP))
-        val vecLit2 = vecFactory.Lit(1 -> (3.25).F(8.W, 4.BP))
+        val vecLit1  = vecFactory.Lit(0 -> (1.5).F(8.W, 4.BP))
+        val vecLit2  = vecFactory.Lit(1 -> (3.25).F(8.W, 4.BP))
 
         vecWire1 := vecLit1
         vecWire1 := vecLit2
@@ -35,11 +35,11 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
         val vecWire1 = Wire(Output(vecFactory))
         val vecWire2 = Wire(Output(vecFactory))
-        val vecLit1 = vecFactory.Lit(0 -> (1.5).F(8.W, 4.BP))
-        val vecLit2 = vecFactory.Lit(1 -> (3.25).F(8.W, 4.BP))
+        val vecLit1  = vecFactory.Lit(0 -> (1.5).F(8.W, 4.BP))
+        val vecLit2  = vecFactory.Lit(1 -> (3.25).F(8.W, 4.BP))
 
-        vecWire1 := vecLit1
-        vecWire2 := vecLit2
+        vecWire1    := vecLit1
+        vecWire2    := vecLit2
         vecWire1(1) := (0.5).F(8.W, 4.BP)
         printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt, vecWire1(1).asUInt)
         chisel3.assert(vecWire1(0) === (1.5).F(8.W, 4.BP))

--- a/src/test/scala/VecLiteralSpec.scala
+++ b/src/test/scala/VecLiteralSpec.scala
@@ -2,6 +2,7 @@
 
 import chisel3.experimental.VecLiterals._
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 import fixedpoint._
 
 import scala.language.reflectiveCalls
@@ -9,7 +10,7 @@ import scala.language.reflectiveCalls
 class VecLiteralSpec extends ChiselFreeSpec with Utils {
   //TODO: decide what behavior here should be
   "This doesn't work should it" ignore {
-    assertTesterPasses {
+    simulate(
       new Module {
         def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
 
@@ -24,11 +25,11 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
         chisel3.assert(vecWire1(1) === (3.25).F(8.W, 4.BP))
         stop()
       }
-    }
+    )(RunUntilFinished(1000))
   }
 
   "partially initialized Vec literals should assign" in {
-    assertTesterPasses {
+    simulate(
       new Module {
         def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
 
@@ -46,6 +47,6 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
         chisel3.assert(vecWire2(1) === (3.25).F(8.W, 4.BP))
         stop()
       }
-    }
+    )(RunUntilFinished(1000))
   }
 }


### PR DESCRIPTION
`UnknownWidth` became a `case object` in this Chisel PR: https://github.com/chipsalliance/chisel/pull/4242

The `connectFromBits` method was removed in this Chisel PR: https://github.com/chipsalliance/chisel/pull/4168

The `connectFromBits` API was replaced with the `_fromUInt` API in this Chisel PR: https://github.com/chipsalliance/chisel/pull/4782

Wrapping unary negation (`unary_-%`) was deprecated in this PR: https://github.com/chipsalliance/chisel/pull/4829

Updating to the latest Chisel/Scala compiler version set off a cascade of updates (scalafmt, scalatest, etc). Hopefully that's alright to include in this PR.